### PR TITLE
ci: bump actions to latest majors and enforce tag-on-main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,13 +18,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
           cache-dependency-path: docs-site/pnpm-lock.yaml
 
@@ -36,7 +36,7 @@ jobs:
         working-directory: docs-site
         run: pnpm build
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs-site/dist
 
@@ -47,5 +47,21 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history so the ancestry check below can walk the graph.
+          fetch-depth: 0
+
+      # Refuse to deploy docs unless the tag is reachable from main.
+      # Pair with publish.yml — neither npm nor Pages should ship for
+      # a tag that wasn't cut from main.
+      - name: Refuse to deploy if tag isn't on main
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor "${{ github.sha }}" origin/main; then
+            echo "::error::Tag ${{ github.ref_name }} (commit ${{ github.sha }}) is not reachable from main. Refusing to deploy docs. Re-run the release from main."
+            exit 1
+          fi
+
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,11 +13,26 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          # Full history so the ancestry check below can walk the graph.
+          fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      # Refuse to publish unless the release tag's commit is reachable
+      # from main. Catches accidental release-it runs from a feature
+      # branch before it's merged — npm gets a clean, main-derived
+      # release, never a dangling-branch one.
+      - name: Refuse to publish if tag isn't on main
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor "${{ github.sha }}" origin/main; then
+            echo "::error::Tag ${{ github.ref_name }} (commit ${{ github.sha }}) is not reachable from main. Refusing to publish. Re-run the release from main."
+            exit 1
+          fi
 
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm


### PR DESCRIPTION
Three bundled changes that together cut the Node 20 deprecation warnings and machine-enforce the "releases come from main" invariant on both the npm and Pages paths.

## 1. Bump actions to Node 24 runtime

GitHub is forcing Node 24 as the default on 2026-06-02 and removing Node 20 entirely on 2026-09-16. All five action pins here were on the older major that targets Node 20 and was annotating every run with a deprecation warning.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `pnpm/action-setup` | v4 | v5 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `actions/deploy-pages` | v4 | v5 |

docs-site `node-version: 22` bumped to `24` to match the runtime the actions run on.

## 2. Enforce tag-on-main in publish.yml

Fires on `release.published`. A release cut from a feature branch that hasn't been merged yet would otherwise publish to npm from a dangling commit — the mistake that bit simplicity-schema-flow's v0.4.0. Added:

```yaml
- name: Refuse to publish if tag isn't on main
  run: |
    git fetch origin main
    if ! git merge-base --is-ancestor "${{ github.sha }}" origin/main; then
      echo "::error::Tag ${{ github.ref_name }} (commit ${{ github.sha }}) is not reachable from main. Refusing to publish."
      exit 1
    fi
```

## 3. Enforce tag-on-main in deploy-docs.yml

Same pattern, in the `deploy` job (the `build` job is cheap and read-only — no need). `deploy-docs.yml` was recently switched from push-on-main to release-triggered (f4c27ca), but no release has been cut since. This PR makes sure the first such release doesn't silently ship docs from an off-main tag.

## Related environment change (already applied)

The `github-pages` environment had a deployment-branch-policy that only allowed the `main` branch. Since `deploy-docs.yml` now fires on releases (ref = tag), every future release would otherwise fail with `Tag vX.Y.Z is not allowed to deploy to github-pages due to environment protection rules` — unrelated to the ancestry check and unrelated to any mistake the user made.

Added a `v*` tag policy to the environment via API (outside this PR's diff). The combination — env allows `v*` tags, workflow refuses tags not on main — is the minimum set for release-triggered docs to work while still rejecting off-main tags.

## Test plan

Can't exercise the refusal path locally without pushing a deliberate off-main tag. Happy path runs on every real release; next release is the first to exercise everything end-to-end.

Precedent: mabulu-inc/simplicity-schema-flow#24 + #25 (same changes, merged).